### PR TITLE
Issue #12: support Meteor 1.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Accounts-drupal
 
-This is an accounts package for Meteor 1.2 to 1.5, using Drupal sessions transparently:
+This is an accounts package for Meteor 1.2 to 1.6, using Drupal sessions transparently:
 
 - The Meteor app is configured to use a specific Drupal server for sessions
 - Any user with a session on the Drupal server is automatically logged in on Meteor, without any UI-level intervention
@@ -10,8 +10,8 @@ This is an accounts package for Meteor 1.2 to 1.5, using Drupal sessions transpa
 
 ## Requirements
 
-- Meteor 1.2.x, 1.3.x, 1.4.x, or 1.5.x
-- Drupal 8.0.x, 8.1.x, 8.2.x or 8.3.x
+- Meteor 1.2.x, 1.3.x, 1.4.x, 1.5.x or 1.6.x
+- Drupal 8.0.x, 8.1.x, 8.2.x, 8.3.x or 8.4.x
 - The Drupal [meteor module] from FGM's Github, not to be confused with the existing [meteor sandbox] from drupal.org.
 - The cookie domain for the Meteor application *must* be the same or a subdomain of the Drupal site. This is a consequence of [cookie scope]. Using the same domain on different IP ports works.
 

--- a/client/DrupalClient.js
+++ b/client/DrupalClient.js
@@ -30,7 +30,8 @@ DrupalClient = class DrupalClient extends DrupalBase {
    * @constructor
    */
   constructor(accounts, meteor, logger, match, stream, template) {
-    super(accounts, meteor, logger, match, stream);
+    super(meteor, logger, match, stream);
+    this.accounts = accounts;
     this.call = (...args) => (meteor.call(...args));
 
     /**

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
  * @file
  *   Package description file for accounts-drupal.
  *
- * Note: package.js is NOT passed to Babel on Meteor 1.2-1.5, so no ES6.
+ * Note: package.js is NOT passed to Babel on Meteor 1.2-1.6, so no ES6.
  */
 
 // Dependencies.
@@ -22,8 +22,8 @@ const coreDependencies = [
 
 Package.describe({
   name: 'fgm:accounts-drupal',
-  version: '0.3.2',
-  summary: 'A Meteor 1.2/1.3/1.4/1.5 accounts system using Drupal 8 sessions.',
+  version: '0.3.3',
+  summary: 'A Meteor 1.2 to 1.6 accounts system using Drupal 8 sessions.',
   git: 'https://github.com/FGM/accounts-drupal',
   documentation: 'README.md'
 });

--- a/server/DrupalConfiguration.js
+++ b/server/DrupalConfiguration.js
@@ -85,3 +85,5 @@ DrupalConfiguration = class DrupalConfiguration {
     this.configurations.upsert(selector, serviceConfig);
   }
 };
+
+export default DrupalConfiguration;

--- a/server/DrupalServer.js
+++ b/server/DrupalServer.js
@@ -35,7 +35,8 @@ DrupalServer = class DrupalServer extends DrupalBase {
    *   An unconfigured service instance.
    */
   constructor(accounts, meteor, logger, match, stream, configuration, http, json) {
-    super(accounts, meteor, logger, match, stream);
+    super(meteor, logger, match, stream);
+    this.accounts = accounts;
     this.updatesCollection = this.getCollection(meteor);
     this.usersCollection = meteor.users;
     this.configuration = configuration;

--- a/server/serverTests.js
+++ b/server/serverTests.js
@@ -1,3 +1,5 @@
+import DrupalConfiguration from './DrupalConfiguration';
+
 const SERVICE_NAME = 'mock-service';
 
 /**
@@ -18,7 +20,7 @@ function mockSettings(serviceName) {
 
 Tinytest.add('Testing correct configuration', function (test) {
   const settings = mockSettings(SERVICE_NAME);
-  settings.public[SERVICE_NAME] = {};
+  settings.public[SERVICE_NAME] = { backgroundLogin: 60 };
 
   let f = new DrupalConfiguration(SERVICE_NAME, settings, Log, ServiceConfiguration);
 
@@ -68,6 +70,9 @@ Tinytest.add('Testing incorrect configuration', function (test) {
   });
 
   // Missing configurations on configuration service.
+  settings[SERVICE_NAME] = {};
+  settings.public = {};
+  settings.public[SERVICE_NAME] = { backgroundLogin: 60 };
   configuration = _.clone(ServiceConfiguration);
   configuration.configurations = null;
   test.throws(instantiation, function (e) {

--- a/shared/Drupal.js
+++ b/shared/Drupal.js
@@ -11,8 +11,8 @@ Log.debug('Defining shared/Drupal');
  * @type {Drupal}
  */
 Drupal = class Drupal extends DrupalBase {
-  constructor(accounts, meteor, log, client, server) {
-    super(accounts, meteor, log);
+  constructor(meteor, log, client, server) {
+    super(meteor, log);
     if (this.location === 'client') {
       check(client, DrupalClient);
     }

--- a/shared/DrupalBase.js
+++ b/shared/DrupalBase.js
@@ -14,8 +14,6 @@ DrupalBase = class DrupalBase {
   /**
    * Constructor.
    *
-   * @param {AccountsClient} accounts
-   *   The AccountsClient service.
    * @param {Meteor} meteor
    *   The Meteor global.
    * @param {Log} logger
@@ -38,8 +36,7 @@ DrupalBase = class DrupalBase {
    *
    * @constructor
    */
-  constructor(accounts, meteor, logger, match, stream) {
-    this.accounts = accounts || null;
+  constructor(meteor, logger, match, stream) {
     this.logger = logger || null;
     this.match = match || null;
     this.stream = stream || null;

--- a/shared/sharedBootPost.js
+++ b/shared/sharedBootPost.js
@@ -18,4 +18,4 @@ if (typeof server === 'undefined') {
   server = null;
 }
 
-drupal = new Drupal(Accounts, Meteor, Log, client, server);
+drupal = new Drupal(Meteor, Log, client, server);


### PR DESCRIPTION
- No longer store accounts on DrupalBase.accounts: the Drupal class does not allow it.
- Fix tests for Meteor 1.6.