### PR TITLE
Issue #16 by @yched: simplify constructor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 help/*.ps
 /node_modules
+settings.json

--- a/client/DrupalClient.js
+++ b/client/DrupalClient.js
@@ -79,13 +79,6 @@ DrupalClient = class DrupalClient extends DrupalBase {
      * @return {Any} id
      */
     this.setInterval = meteor.setInterval.bind(this);
-    /**
-     * The Meteor.setTimeout() function, bound to this.
-     *
-     * @param {Function} func
-     * @param {number} delay
-     */
-    this.setTimeout = meteor.setTimeout.bind(this);
     this.template = template;
     this.user = meteor.user.bind(this);
 


### PR DESCRIPTION
- no need to call getInterval()
- renamed this.actualLoginInterval/getInterval() to [get]backgroundLoginDelay
- removed unused this.setTimeout on DrupalClient