### PR TITLE
Issue #27: stop using exceptions in normal operation, clean logs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,0 @@
-.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,7 +49,7 @@ module.exports = {
   },
 
   'parser': 'babel-eslint',
-  'plugins': ['react'],
+  'plugins': [],
 
   'parserOptions': {
     'ecmaFeatures': {
@@ -80,6 +80,7 @@ module.exports = {
     'sourceType': "module"
   },
 
+  'root': true,
   'rules': {
 
     //
@@ -270,24 +271,5 @@ module.exports = {
     'max-statements': 0, // specify the maximum number of statement allowed in a function (off by default)
     'no-bitwise': 0, // disallow use of bitwise operators (off by default)
     'no-plusplus': 0, // disallow use of unary operators, ++ and -- (off by default)
-
-    //
-    // eslint-plugin-react
-    //
-    // React specific linting rules for ESLint
-    //
-    'react/display-name': 0, // Prevent missing displayName in a React component definition
-    'react/jsx-no-undef': 2, // Disallow undeclared variables in JSX
-    'react/jsx-sort-props': 0, // Enforce props alphabetical sorting
-    'react/jsx-uses-react': 2, // Prevent React to be incorrectly marked as unused
-    'react/jsx-uses-vars': 2, // Prevent variables used in JSX to be incorrectly marked as unused
-    'react/no-did-mount-set-state': 1, // Prevent usage of setState in componentDidMount
-    'react/no-did-update-set-state': 1, // Prevent usage of setState in componentDidUpdate
-    'react/no-multi-comp': 0, // Prevent multiple component definition per file
-    'react/no-unknown-property': 2, // Prevent usage of unknown DOM property
-    'react/prop-types': 2, // Prevent missing props validation in a React component definition
-    'react/react-in-jsx-scope': 0, // Prevent missing React when using JSX
-    'react/self-closing-comp': 2, // Prevent extra closing tags for components without children
-    'react/jsx-wrap-multilines': 2 // Prevent missing parentheses around multilines JSX
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,10 +10,17 @@ module.exports = {
     // Meteor
     '$': true,
     '_': true,
+    'IncomingMessage': true,
+    'ServerResponse': true,
 
     'Accounts': true,
+    'AccountsClient': true,
+    'AccountsServer': true,
     'HTTP': true,
     'Log': true,
+    'IHTTP': true,
+    'IMatch': true,
+    'ITemplate': true,
     'Match': true,
     'Meteor': true,
     'Mongo': true,
@@ -25,6 +32,9 @@ module.exports = {
     'Tinytest': true,
     'WebApp': true,
     'check': true,
+
+    // RocketChat::Streamer
+    'Streamer': true,
 
     // The globals defined in this package.
     'Drupal': true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## 0.4.x: developer and admin experience
+- 0.4.2 
+  - Made logs both less verbose and more useful. 
+  - Cookie check implementation simplified, no longer using exceptions
+  - new CHANGELOG.md file
+  - Removed unneeded eslint-plugin-react dependency
+- 0.4.1 Fixed error invoking login callback on failed login.
+- 0.4.0 Control of package initialization 
+  - Support for Meteor 1.8.x. Earlier versions dropped.
+  - Initialization triggered in Meteor.startup(), not a package side-effect
+  - Use dependency injection a lot more instad of pulling Meteor globals
+  - Major code restructuring 
+
+## 0.3.x: production improvements
+
+- 0.3.6 Support Meteor 1.2-1.7, and Symfony 3.x/4.x backends in addition to Drupal 8 
+- 0.3.5 Templating package (Blaze) made optional.
+- 0.3.4 Login peaks avoidance, with pseudo-randomized background login refresh
+- 0.3.3 Support for Meteor 1.2-1.6.
+- 0.3.2 New "updaters" setting to limit authorized backends. ESLint review.
+- 0.3.1 Reduced logging verbosity, Meteor 1.2-1.4, Drupal 8.0-8.3 support
+- 0.3.0 Robustness 
+  - Reduced broadcast scope over streamer
+  - Removed public autologin setting
+  - Handling of all Drupal 8 user/field events
+  - Design documentation in OPERATION.md
+  - Use of single Connect route for push notifications from Drupal server
+  
+## 0.2.x: first production
+
+- 0.2.6 Switch from arunoda:streams/fgm:streams to rocketchat:streamer
+- 0.2.5 Support for Meteor 1.2-1.4
+- 0.2.4 Support for multi-server (redundant) topologies
+- 0.2.3 Support for BasicAuth authentication to the Drupal backend
+- 0.2.2 Documentation improvements
+- 0.2.1 First working release for Meteor 1.2-1.3, using fgm:streams
+
+## 0.0.x Early efforts
+
+- 0.1.x never existed
+- 0.0.1 unpublished version, for Meteor 1.2, using arunoda:streams

--- a/cl/DrupalClient.js
+++ b/cl/DrupalClient.js
@@ -131,14 +131,8 @@ class DrupalClient extends DrupalBase {
     let result = {};
     asArray.forEach((v) => {
       let [name, value] = v.trim().split('=');
-      try {
-        this.checkCookie(name, value);
+      if (this.checkCookie(name, value)) {
         result[name] = value;
-      }
-      catch (e) {
-        if (!(e instanceof Match.Error)) {
-          throw e;
-        }
       }
     });
     return result;

--- a/cl/DrupalClient.js
+++ b/cl/DrupalClient.js
@@ -5,8 +5,6 @@
 
 import { DrupalBase } from '../shared/DrupalBase';
 
-const SERVICE_NAME = DrupalBase.SERVICE_NAME;
-
 /**
  * The client-side class for the package.
  *
@@ -203,12 +201,12 @@ class DrupalClient extends DrupalBase {
       // because it happens in a loop. Do NOT remove that property.
       userCallback: (err, res) => {
         if (err) {
-          this.logger.warn(Object.assign(logArg, { message: `Not logged-in with ${SERVICE_NAME}` }));
+          this.logger.warn(Object.assign(logArg, { message: `Not logged-in with ${this.SERVICE_NAME}` }));
           this.logout();
         }
         else {
           this.backgroundLoginEnable();
-          this.logger.debug(Object.assign(logArg, { message: `Logged-in with ${SERVICE_NAME}` }));
+          this.logger.debug(Object.assign(logArg, { message: `Logged-in with ${this.SERVICE_NAME}` }));
         }
         if (_.isFunction(callback)) {
           callback(err, res);
@@ -299,9 +297,9 @@ class DrupalClient extends DrupalBase {
     }
 
     const helpers = [
-      { name: 'accountsDrupalUserId', code: () => client.uid },
-      { name: 'accountsDrupalUsername', code: () => client.name },
-      { name: 'accountsDrupalRoles', code: () => client.roles }
+      { name: 'accountsDrupalUserId', code: () => this.uid },
+      { name: 'accountsDrupalUsername', code: () => this.name },
+      { name: 'accountsDrupalRoles', code: () => this.roles }
     ];
 
     helpers.forEach(({ name, code }) => this.template.registerHelper(name, code));
@@ -314,7 +312,7 @@ class DrupalClient extends DrupalBase {
 
   get uid() {
     const user = this.user();
-    const uid = user ? parseInt(user.profile[client.SERVICE_NAME].uid, 10) : 0;
+    const uid = user ? parseInt(user.profile[this.SERVICE_NAME].uid, 10) : 0;
     return uid;
   }
 

--- a/cl/DrupalClient.js
+++ b/cl/DrupalClient.js
@@ -5,6 +5,8 @@
 
 import { DrupalBase } from "../shared/DrupalBase"
 
+const SERVICE_NAME = DrupalBase.SERVICE_NAME;
+
 /**
  * The client-side class for the package.
  *
@@ -123,7 +125,7 @@ class DrupalClient extends DrupalBase {
    * @returns {Object}
    *   A cookie-name:cookie-value hash.
    */
-  cookies(cookie) {
+  candidateCookies(cookie) {
     check(cookie, String);
     let asArray = cookie.split(';');
     let result = {};
@@ -177,7 +179,7 @@ class DrupalClient extends DrupalBase {
    */
   login(cookie, callback = null) {
     let logArg = { app: this.SERVICE_NAME };
-    const cookies = this.cookies(cookie);
+    const cookies = this.candidateCookies(cookie);
 
     if (_.isEmpty(cookies)) {
       let message;
@@ -209,12 +211,12 @@ class DrupalClient extends DrupalBase {
       // because it happens in a loop. Do NOT remove that property.
       userCallback: (err, res) => {
         if (err) {
-          this.logger.warn(Object.assign(logArg, { message: 'Not logged-in on Drupal.' }));
+          this.logger.warn(Object.assign(logArg, { message: `Not logged-in with ${SERVICE_NAME}` }));
           this.logout();
         }
         else {
           this.backgroundLoginEnable();
-          this.logger.debug(Object.assign(logArg, { message: 'Logged-in on Drupal.' }));
+          this.logger.debug(Object.assign(logArg, { message: `Logged-in with ${SERVICE_NAME}` }));
         }
         if (_.isFunction(callback)) {
           callback(err, res);

--- a/cl/DrupalClient.js
+++ b/cl/DrupalClient.js
@@ -3,7 +3,7 @@
  *   Contains the DrupalClient class.
  */
 
-import { DrupalBase } from "../shared/DrupalBase"
+import { DrupalBase } from '../shared/DrupalBase';
 
 const SERVICE_NAME = DrupalBase.SERVICE_NAME;
 
@@ -32,8 +32,6 @@ class DrupalClient extends DrupalBase {
    *   A Meteor logger service.
    * @param {Object} publicSettings
    *   The public portion of Meteor.settings.
-   *
-   * @constructor
    */
   constructor(accounts, match, meteor, random, template, stream, logger, publicSettings) {
     super(meteor, logger, match, stream);
@@ -105,7 +103,7 @@ class DrupalClient extends DrupalBase {
    *
    * Do nothing if it is already active.
    *
-   * @return {void}
+   * @returns {undefined}
    */
   backgroundLoginEnable() {
     if (!this.backgroundLoginInterval) {
@@ -119,7 +117,7 @@ class DrupalClient extends DrupalBase {
   /**
    * Convert a JS-style cookie string to a hash of Drupal-plausible cookies.
    *
-   * @param {String} cookie
+   * @param {string} cookie
    *   The cookie string in JS semicolon-separated format.
    *
    * @returns {Object}
@@ -164,12 +162,12 @@ class DrupalClient extends DrupalBase {
   /**
    * The method to use to perform login.
    *
-   * @param {String} cookie
+   * @param {string} cookie
    *   JS semicolon-separated cookie string.
-   * @param {function} callback
+   * @param {Function} callback
    *   Optional. Callback after login, as userCallback(err, res).
    *
-   * @return {void}
+   * @returns {undefined}
    */
   login(cookie, callback = null) {
     let logArg = { app: this.SERVICE_NAME };
@@ -222,15 +220,12 @@ class DrupalClient extends DrupalBase {
   /**
    * An optional helper to log out.
    *
-   * @returns {void}
+   * @returns {undefined}
    */
   logout() {
     this.accounts.logout();
   }
 
-  /**
-   * @inheritDoc
-   */
   initStateMethod() {
     this.logger.debug('Client stub for initStateMethod, doing nothing.');
     return this.getDefaultUser();
@@ -241,7 +236,7 @@ class DrupalClient extends DrupalBase {
    *
    * If invoked for an anonymous user, disable the background process.
    *
-   * @return {void}
+   * @returns {undefined}
    */
   onBackgroundLogin() {
     this.logger.debug('Background login check');
@@ -262,7 +257,7 @@ class DrupalClient extends DrupalBase {
    * @param {number} userId
    *   The userId, if event is "userId".
    *
-   * @returns {void}
+   * @returns {undefined}
    *
    * @see DrupalServer.observe()
    */
@@ -296,7 +291,7 @@ class DrupalClient extends DrupalBase {
   /**
    * Register template helpers for Blaze if template is available.
    *
-   * @returns {void}
+   * @returns {undefined}
    */
   registerHelpers() {
     if (!this.template) {
@@ -312,11 +307,8 @@ class DrupalClient extends DrupalBase {
     helpers.forEach(({ name, code }) => this.template.registerHelper(name, code));
   }
 
-  /**
-   * @inheritDoc
-   */
   whoamiMethod(cookieName, cookieValue) {
-    this.logger.info(`Client stub for whoamiMethod(${cookieName}, ${cookieValue}), returning default user.`);
+    this.logger.debug(`Client stub for whoamiMethod(${cookieName}, ${cookieValue}), returning default user.`);
     return this.getDefaultUser();
   }
 
@@ -341,4 +333,4 @@ class DrupalClient extends DrupalBase {
 
 export {
   DrupalClient,
-}
+};

--- a/cl/DrupalClient.js
+++ b/cl/DrupalClient.js
@@ -292,7 +292,7 @@ class DrupalClient extends DrupalBase {
         break;
 
       default:
-        this.logger.info(`Received unknown event ${event}(${userId}): ignored`);
+        this.logger.warn(`Received unknown event ${event}(${userId}): ignored`);
         break;
     }
   }

--- a/cl/DrupalClient.js
+++ b/cl/DrupalClient.js
@@ -271,8 +271,7 @@ class DrupalClient extends DrupalBase {
    * @see DrupalServer.observe()
    */
   onRefresh(event, userId) {
-    this.logger.info('Automatic login status update: ' + event + '(' + userId + ')');
-    // this.login(document.cookie);
+    this.logger.debug('Automatic login status update: ' + event + '(' + userId + ')');
     switch (event) {
       case 'anonymous':
         if (!this.user()) {

--- a/cl/clientMain.js
+++ b/cl/clientMain.js
@@ -27,7 +27,7 @@ import { makeClient } from "./makeClient";
 const onLoginFactory = (logger, client) => {
   const onLogin = (callback) => {
     if (document.cookie) {
-      logger.info("Cookies exist, attempting Drupal login");
+      logger.debug("Cookies exist, attempting Drupal login");
       // Attempt login if a cookie exists, logout otherwise.
       // XXX Consider taking a callback from the application here.
       client.login(document.cookie, callback);

--- a/cl/clientMain.js
+++ b/cl/clientMain.js
@@ -8,31 +8,35 @@
  * - it stores a Drupal instance as the "drupal" global.
  */
 
-import { Accounts } from "meteor/accounts-base";
-import { Match } from "meteor/check";
-import { Meteor } from "meteor/meteor";
-import { Random } from "meteor/random";
+import { Accounts } from 'meteor/accounts-base';
+import { Match } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import { Random } from 'meteor/random';
 
-import { Drupal } from "../shared/Drupal";
-import { makeClient } from "./makeClient";
+import { Drupal } from '../shared/Drupal';
+import { makeClient } from './makeClient';
 
 /**
- * onLoginFactory returns a Meteor login function.
+ * Function onLoginFactory returns a Meteor login function.
  *
  * @param {Log} logger
+ *   A logger instance compatible with Meteor Log.
  * @param {DrupalClient} client
+ *   A configured DrupalClient instance.
  *
- * @return {onLogin}
+ * @returns {Function}
+ *   A Meteor login function.
  */
 const onLoginFactory = (logger, client) => {
   const onLogin = (callback) => {
     if (document.cookie) {
-      logger.debug("Cookies exist, attempting Drupal login");
+      logger.debug('Cookies exist, attempting Drupal login');
       // Attempt login if a cookie exists, logout otherwise.
       // XXX Consider taking a callback from the application here.
       client.login(document.cookie, callback);
-    } else if (_.isFunction(callback)) {
-      callback(new Meteor.Error("No cookie: cannot login"), null);
+    }
+    else if (_.isFunction(callback)) {
+      callback(new Meteor.Error('No cookie: cannot login'), null);
     }
   };
 
@@ -40,7 +44,7 @@ const onLoginFactory = (logger, client) => {
 };
 
 /**
- * A Meteor.startup() argument function
+ * A Meteor.startup() argument function.
  *
  * That function builds a client instance and exposes it as the "drupal" global.
  *
@@ -48,10 +52,10 @@ const onLoginFactory = (logger, client) => {
  *   A Log-compatible logger.
  * @param {Object} settings
  *   The public portion of Meteor.settings.
- * @param {Template|null} template
+ * @param {Template|Object} template
  *   The Template service, or null when not using Blaze.
  *
- * @return {void}
+ * @returns {undefined}
  */
 const onStartup = (logger, settings, template = null) => {
   logger.debug('Client startup');
@@ -66,7 +70,7 @@ const onStartup = (logger, settings, template = null) => {
    * @param {function} callback
    *   Optional. A callback to be called at the end of login, with (err, res).
    *
-   * @return {void}
+   * @returns {undefined}
    */
   Meteor.loginWithDrupal = onLoginFactory(logger, client);
 };

--- a/cl/makeClient.js
+++ b/cl/makeClient.js
@@ -33,7 +33,7 @@ const makeClient = (accounts, match, meteor, random, template, logger, settings)
     );
 
     // Register the package ? Nothing to do client-side.
-    logger.debug('Accounts-drupal configured');
+    logger.debug(`${DrupalBase.SERVICE_NAME} service configured`);
   }
   catch (e) {
     // Do not return an apparently usable instance if an exception occurred.

--- a/cl/makeClient.js
+++ b/cl/makeClient.js
@@ -5,8 +5,8 @@
  * - Meteor.loginWithDrupal([options, ]callback)
  */
 
-import { DrupalClient } from "./DrupalClient";
-import { DrupalBase } from "../shared/DrupalBase";
+import { DrupalClient } from './DrupalClient';
+import { DrupalBase } from '../shared/DrupalBase';
 
 const makeClient = (accounts, match, meteor, random, template, logger, settings) => {
   let client;
@@ -46,4 +46,4 @@ const makeClient = (accounts, match, meteor, random, template, logger, settings)
 
 export {
   makeClient,
-}
+};

--- a/package.js
+++ b/package.js
@@ -20,7 +20,7 @@ const coreDependencies = [
 
 Package.describe({
   name: 'fgm:accounts-drupal',
-  version: '0.4.1',
+  version: '0.4.2',
   summary: 'A Meteor 1.8 accounts system using cookie-based login on a Drupal 8 or Symfony server.',
   git: 'https://github.com/fgm/accounts-drupal',
   documentation: 'README.md'

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "devDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.14.1",
-    "eslint-plugin-react": "^7.12.4"
+    "eslint": "^5.14.1"
   },
   "scripts": {
-    "lint": "eslint shared sv cl"
+    "lint": "eslint -c .eslintrc.js shared sv cl"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
-    "babel-eslint": "^10.0",
-    "eslint": "^5.9",
-    "eslint-plugin-react": "^7.11.1"
+    "babel-eslint": "^10.0.1",
+    "eslint": "^5.13",
+    "eslint-plugin-react": "^7.12.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.13",
+    "eslint": "^5.14.1",
     "eslint-plugin-react": "^7.12.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
     "babel-eslint": "^10.0.1",
     "eslint": "^5.14.1",
     "eslint-plugin-react": "^7.12.4"
+  },
+  "scripts": {
+    "lint": "eslint shared sv cl"
   }
 }

--- a/shared/Drupal.js
+++ b/shared/Drupal.js
@@ -3,9 +3,9 @@
  *   Contains the Drupal composite class.
  */
 
-import { DrupalBase } from "./DrupalBase";
-import { DrupalClient } from "../cl/DrupalClient";
-import { DrupalServer } from "../sv/DrupalServer";
+import { DrupalBase } from './DrupalBase';
+import { DrupalClient } from '../cl/DrupalClient';
+import { DrupalServer } from '../sv/DrupalServer';
 
 /**
  * The shared class composing DrupalClient and DrupalServer.
@@ -78,4 +78,4 @@ class Drupal extends DrupalBase {
 
 export {
   Drupal,
-}
+};

--- a/shared/DrupalBase.js
+++ b/shared/DrupalBase.js
@@ -32,8 +32,6 @@ class DrupalBase {
    *
    * @returns {DrupalBase}
    *   An unconfigured base instance, meant for child use.
-   *
-   * @constructor
    */
   constructor(meteor, logger, match, stream) {
     this.logger = logger || null;
@@ -66,16 +64,16 @@ class DrupalBase {
    *
    * @see \Drupal\Component\Utility\Crypt::randomBytesBase64()
    *
-   * @param {String} name
+   * @param {string} name
    *   The cookie name.
-   * @param {String} value
+   * @param {string} value
    *   The cookie value (id).
    *
    * @returns {boolean}
    *   Did plausibility checks pass ?
    */
   checkCookie(name, value) {
-    if (typeof name !== 'string' || typeof value !== 'string') {
+    if (typeof name !== 'string' || typeof value !== 'string') {
       return false;
     }
     const NAME_REGEXP = /^SESS[0-9A-F]{32}$/i;
@@ -95,15 +93,15 @@ class DrupalBase {
   /**
    * Abstract base method for "accounts-drupal:initState".
    *
-   * @param {Boolean} refresh
+   * @param {boolean} refresh
    *   On server, perform a Drupal WS call if true, otherwise use the instance
    *   information. Ignored on client.
    *
    * @returns {Object}
-   *   - cookieName: the name of the session cookie used by the site.
-   *   - anonymousName: the name of the anonymous user to use when not logged
-   *   in.
-   *   - online: site was available at last check.
+   *   - Key cookieName: the name of the session cookie used by the site.
+   *   - Key anonymousName: the name of the anonymous user to use when not
+   *     logged in.
+   *   - Key online: site was available at last check.
    */
   initStateMethod(refresh = false) {
     throw new Meteor.Error('abstract-method', 'initStateMethod is abstract: use a concrete implementation instead.');
@@ -112,15 +110,15 @@ class DrupalBase {
   /**
    * Abstract base method for "accounts-drupal:whoami".
    *
-   * @param {String} cookieName
+   * @param {string} cookieName
    *   The cookie name.
-   * @param {String} cookieValue
+   * @param {string} cookieValue
    *   The cookie value.
    *
    * @returns {Object}
-   *   - uid: a Drupal user id, 0 if not logged on Drupal
-   *   - name: a Drupal user name, defaulting to the settings-defined anonymous.
-   *   - roles: an array of role names, possibly empty.
+   *   - Key uid: a Drupal user id, 0 if not logged on Drupal.
+   *   - Key name: a Drupal user name, defaulting to the settings-defined anonymous.
+   *   - Key roles: an array of role names, possibly empty.
    */
   whoamiMethod(cookieName, cookieValue) {
     throw new Meteor.Error('abstract-method', `whoamiMehod(${cookieName}, ${cookieValue}) is abstract: use a concrete implementation instead.`);
@@ -213,4 +211,4 @@ class DrupalBase {
 
 export {
   DrupalBase,
-}
+};

--- a/shared/DrupalBase.js
+++ b/shared/DrupalBase.js
@@ -87,14 +87,13 @@ class DrupalBase {
       const NAME_REGEXP = /^SESS[0-9A-F]{32}$/i;
       if (!NAME_REGEXP.exec(checkedName)) {
         const message = `Checked invalid cookie name ${checkedName}.`;
-        that.logger.debug(message);
         throw new that.match.Error(message);
       }
       // @FIXME Temporary fix for SF4 handler emitting possibly short values.
       const VALUE_REGEXP = /^[\w_-]{1,128}$/i;
       if (!VALUE_REGEXP.exec(checkedValue)) {
         const message = `Checked invalid cookie value ${checkedValue}.`;
-        that.logger.debug(message);
+        that.logger.warn(message);
         throw new that.match.Error(message);
       }
       return true;

--- a/sv/DrupalConfiguration.js
+++ b/sv/DrupalConfiguration.js
@@ -2,7 +2,7 @@
  * @file
  *   The configuration of accounts-drupal.
  */
-import { _ } from "meteor/underscore";
+import { _ } from 'meteor/underscore';
 
 /**
  * Configure the service from its settings.
@@ -12,11 +12,14 @@ class DrupalConfiguration {
    * Constructor.
    *
    * @param {Meteor} meteor
+   *   The Meteor global.
    * @param {Object} serviceConfiguration
+   *   The ServiceConfiguration service.
    * @param {Log} logger
+   *   The Meteor Log service.
    * @param {Object} settings
    *   Meteor settings.
-   * @param {String} name
+   * @param {string} name
    *   The name of the service.
    *
    * @returns {DrupalConfiguration}
@@ -67,10 +70,10 @@ class DrupalConfiguration {
   /**
    * Update the stored configuration from the current instance.
    *
-   * @param {String} name
+   * @param {string} name
    *   The name of the Drupal login service.
    *
-   * @return {void}
+   * @returns {undefined}
    */
   persist(name) {
     const selector = { service: name };
@@ -86,4 +89,4 @@ class DrupalConfiguration {
 
 export {
   DrupalConfiguration,
-}
+};

--- a/sv/DrupalServer.js
+++ b/sv/DrupalServer.js
@@ -8,6 +8,8 @@ import util from "util";
 
 import { DrupalBase } from "../shared/DrupalBase";
 
+const SERVICE_NAME = DrupalBase.SERVICE_NAME;
+
 /**
  * A class providing the mechanisms for the "drupal" accounts service.
  *
@@ -51,8 +53,8 @@ class DrupalServer extends DrupalBase {
     this.setupUpdatesObserver();
 
     // - Merge Meteor settings to instance.
-    Object.assign(this.settings.server, meteor.settings[DrupalBase.SERVICE_NAME]);
-    Object.assign(this.settings.client, meteor.settings.public[DrupalBase.SERVICE_NAME]);
+    Object.assign(this.settings.server, meteor.settings[SERVICE_NAME]);
+    Object.assign(this.settings.client, meteor.settings.public[SERVICE_NAME]);
 
     // - Initialize Drupal-dependent state.
     this.state = this.initStateMethod(true);
@@ -131,7 +133,7 @@ class DrupalServer extends DrupalBase {
     const totalSubscriptionCount = this.stream.subscriptions.length;
     const eventSubscriptions = this.stream.subscriptionsByEventName[this.EVENT_NAME];
     const eventSubscriptionCount = eventSubscriptions ? eventSubscriptions.length : 0;
-    this.logger.info(`emitting ${action}(${userId}) to ${eventSubscriptionCount} subscription for ${this.EVENT_NAME}, out of ${totalSubscriptionCount} overall subscriptions\n`);
+    this.logger.info(`Emitting ${action}(${userId}) to ${eventSubscriptionCount} subscription for ${this.EVENT_NAME}, out of ${totalSubscriptionCount} overall subscriptions\n`);
     this.stream.emit(this.EVENT_NAME, action, userId);
   }
 
@@ -263,14 +265,14 @@ class DrupalServer extends DrupalBase {
     // any login package will only look for login request information under its
     // own service name, returning undefined otherwise.
     const cookies = loginRequest[NAME];
-    let loginResult = this.loginCheck(cookies, 'Login not handled.', false);
+    let loginResult = this.loginCheck(cookies, `Login not handled by ${SERVICE_NAME}.`, false);
     if (loginResult) {
       return loginResult;
     }
 
     this.logger.debug({
       app: NAME,
-      message: 'Drupal login attempt',
+      message: `${SERVICE_NAME} login attempt`,
       cookies
     });
 
@@ -471,7 +473,7 @@ class DrupalServer extends DrupalBase {
         break;
 
       default:
-        this.logger.warn('Observed unsupported event type ' + doc.event);
+        this.logger.warn(`Observed unsupported event type ${doc.event}`);
         break;
     }
   }

--- a/sv/DrupalServer.js
+++ b/sv/DrupalServer.js
@@ -277,7 +277,7 @@ class DrupalServer extends DrupalBase {
     });
 
     // Shortcut: avoid WS call if Drupal is not available.
-    loginResult = this.loginCheck(this.state.online, 'Drupal server is not online.');
+    loginResult = this.loginCheck(this.state.online, 'Drupal server is not online.', true);
     if (loginResult) {
       return loginResult;
     }
@@ -285,23 +285,17 @@ class DrupalServer extends DrupalBase {
     // Shortcut: avoid WS call if cookie name is not the expected one.
     const cookieName = this.state.cookieName;
     const cookieValue = cookies[cookieName];
-    loginResult = this.loginCheck(cookieValue, 'No cookie matches Drupal session name.');
+    loginResult = this.loginCheck(cookieValue, 'No cookie matches Drupal session name.', false);
     if (loginResult) {
       return loginResult;
     }
 
     // Shortcut: avoid WS call if cookie value is malformed.
-    try {
-      // Never forget to check tainted data like these.
-      this.checkCookie(cookieName, cookieValue);
-    }
-    catch (e) {
-      let expectedException = e instanceof Match.Error;
-      loginResult = this.loginCheck(expectedException, 'Malformed session cookie');
-      if (loginResult) {
-        return loginResult;
-      }
-      throw e;
+    // Never forget to check tainted data like these.
+    const cookieIsPlausible = this.checkCookie(cookieName, cookieValue);
+    loginResult = this.loginCheck(cookieIsPlausible, 'Malformed session cookie', false);
+    if (loginResult) {
+      return loginResult;
     }
 
     // Perform the actual web service call. Exceptions are caught and return

--- a/sv/DrupalServer.js
+++ b/sv/DrupalServer.js
@@ -3,10 +3,10 @@
  *   Contains the DrupalServer class.
  */
 
-import nodeUrl from "url";
-import util from "util";
+import nodeUrl from 'url';
+import util from 'util';
 
-import { DrupalBase } from "../shared/DrupalBase";
+import { DrupalBase } from '../shared/DrupalBase';
 
 const SERVICE_NAME = DrupalBase.SERVICE_NAME;
 
@@ -24,9 +24,11 @@ class DrupalServer extends DrupalBase {
    * @param {Meteor} meteor
    *   The Meteor global.
    * @param {Log} logger
-   *   the Meteor Log service.
+   *   The Meteor Log service.
    * @param {IMatch} match
    *   The Meteor check matcher service.
+   * @param {WebApp} webapp
+   *   The Meteor webapp service.
    * @param {Streamer} stream
    *   The stream used by the package.
    * @param {ServiceConfiguration} configuration
@@ -62,21 +64,21 @@ class DrupalServer extends DrupalBase {
       logger.debug('Retrieved Drupal site information.');
     }
     else {
-      throw new meteor.Error("init-state", `Could not reach Drupal server at ${this.settings.server.site}.`);
+      throw new meteor.Error('init-state', `Could not reach Drupal server at ${this.settings.server.site}.`);
     }
   }
 
   /**
    * Check a condition and if it fails, build a loginResult failure.
    *
-   * @param {Boolean} condition
+   * @param {boolean} condition
    *   The condition to check.
-   * @param {String} message
+   * @param {string} message
    *   The message for failure cases.
-   * @param {Boolean} notify
+   * @param {boolean} notify
    *   Log a fail result.
    *
-   * @returns {Object|false}
+   * @returns {Object|boolean}
    *   - If the condition is false, a failing login result object.
    *   - Otherwise, false.
    */
@@ -100,10 +102,10 @@ class DrupalServer extends DrupalBase {
    *
    * This is invoked only if autopublish is enabled.
    *
-   * @return {Object}
+   * @returns {Object}
    *   An object with up to two keys:
-   *   - forLoggedInUsers: an array of fields published to the current user
-   *   - forOtherUsers: an array of fields published to other users
+   *   - Key forLoggedInUsers: an array of fields published to the current user.
+   *   - Key forOtherUsers: an array of fields published to other users.
    */
   autopublishFields() {
     const allFields = `services.${this.SERVICE_NAME}`;
@@ -120,14 +122,12 @@ class DrupalServer extends DrupalBase {
   /**
    * Emit a SSO event on the SSO stream.
    *
-   *   The event details
-   *
-   * @param {String} action
+   * @param {string} action
    *   The action to perform. Currently only valid value is "login".
-   * @param {Number} userId
+   * @param {number} userId
    *   The integer user id to filter on, or 0 for any user.
    *
-   * @returns {void}
+   * @returns {undefined}
    */
   emit(action, userId = 0) {
     const totalSubscriptionCount = this.stream.subscriptions.length;
@@ -141,7 +141,7 @@ class DrupalServer extends DrupalBase {
    * Return the collection used for updates.
    *
    * @param {Meteor} meteor
-   *   The Meteor service
+   *   The Meteor service.
    *
    * @returns {Mongo.Collection|Meteor.Collection|*}
    *   The updates collection.
@@ -204,7 +204,11 @@ class DrupalServer extends DrupalBase {
    * The controller for the web route used to notify the package about changes.
    *
    * @param {IncomingMessage} req
+   *   The request object.
    * @param {ServerResponse} res
+   *   The response object.
+   *
+   * @returns {undefined}
    */
   handleUserEvent(req, res) {
     res.writeHead(200);
@@ -251,7 +255,7 @@ class DrupalServer extends DrupalBase {
    *   The login request passed by Meteor. It will be of interest to the package
    *   only if it contains a key named after the package.
    *
-   * @return {Object} The result of a login request
+   * @returns {Object} The result of a login request
    *   - Undefined if the package does not handle this request.
    *   - False if the package rejects the request.
    *   - A result object containing the user information in case of login success.
@@ -273,7 +277,7 @@ class DrupalServer extends DrupalBase {
     this.logger.debug({
       app: NAME,
       message: `${SERVICE_NAME} login attempt`,
-      cookies
+      cookies,
     });
 
     // Shortcut: avoid WS call if Drupal is not available.
@@ -348,7 +352,7 @@ class DrupalServer extends DrupalBase {
    *
    * @see AccountsServer._initServerPublications()
    *
-   * @returns {void}
+   * @returns {undefined}
    */
   register() {
     let that = this;
@@ -363,7 +367,7 @@ class DrupalServer extends DrupalBase {
   /**
    * Autopublish custom fields on startup, based on configuration.
    *
-   * @returns {void}
+   * @returns {undefined}
    */
   registerAutopublish() {
     this.accounts.addAutopublishFields(this.autopublishFields());
@@ -372,7 +376,6 @@ class DrupalServer extends DrupalBase {
   registerWebRoute() {
     // This path must match the one in Drupal module at meteor/src/Notifier::PATH.
     this.webapp.connectHandlers.use('/drupalUserEvent', this.handleUserEvent.bind(this));
-
   }
 
   /**
@@ -381,13 +384,13 @@ class DrupalServer extends DrupalBase {
    * This method can be used as a Drupal method (hence its name), but the
    * default logic does not require it.
    *
-   * @param {Boolean} refresh
+   * @param {boolean} refresh
    *   Perform a Drupal WS call if true, otherwise use the instance information.
    *
    * @returns {Object}
-   *   - cookieName: the name of the session cookie used by the site.
-   *   - anonymousName: the name of the anonymous user to use when not logged in.
-   *   - online: site was available at last check.
+   *   - Key cookieName: the name of the session cookie used by the site.
+   *   - Key anonymousName: the name of the anonymous user to use when not logged in.
+   *   - Key online: site was available at last check.
    */
   initStateMethod(refresh = false) {
     if (!refresh) {
@@ -425,12 +428,12 @@ class DrupalServer extends DrupalBase {
   /**
    * Handle collection change events.
    *
-   * @param {String} changeType
+   * @param {string} changeType
    *   The change type: added, changed.
    * @param {Object} doc
    *   An affected documents.
    *
-   * @returns {void}
+   * @returns {undefined}
    */
   observe(changeType, doc) {
     if (changeType !== 'added') {
@@ -478,7 +481,7 @@ class DrupalServer extends DrupalBase {
    * - Initialize the TTL index on the package updates collection
    * - Observe it.
    *
-   * @returns {void}
+   * @returns {undefined}
    */
   setupUpdatesObserver() {
     this.updatesCollection._ensureIndex({ createdAt: 1 }, { expireAfterSeconds: 300 });
@@ -499,13 +502,14 @@ class DrupalServer extends DrupalBase {
    *     - "field_delete", "field_insert", "field_update",
    *     - "entity_field_update"
    *   - {int} delay: the delay to wait before inserting the event, in msec.
-   * @param remoteAddress
+   * @param {string} remoteAddress
    *   The address of the HTTP client (or proxy).
    *
-   * @returns {void}
+   * @returns {undefined}
    *
    * @see \Drupal\meteor\IdentityListener::__destruct()
-   * @TODO handle proxies.
+   *
+   * TODO handle proxies.
    */
   storeUpdateRequest(rawQuery, remoteAddress) {
     const index = this.settings.server.updaters.indexOf(remoteAddress);
@@ -565,10 +569,10 @@ class DrupalServer extends DrupalBase {
   /**
    * Delete user by id.
    *
-   * @param {Number} rawUserId
+   * @param {number} rawUserId
    *   The Drupal uid for the user.
    *
-   * @returns {void}
+   * @returns {undefined}
    */
   userDelete(rawUserId) {
     const userId = parseInt(rawUserId, 10);
@@ -581,15 +585,15 @@ class DrupalServer extends DrupalBase {
   /**
    * Call the Drupal whoami service.
    *
-   * @param {String} cookieName
+   * @param {string} cookieName
    *   The cookie name.
-   * @param {String} cookieValue
+   * @param {string} cookieValue
    *   The cookie value. May be null.
    *
    * @returns {Object}
-   *   - uid: a Drupal user id, 0 if not logged on Drupal
-   *   - name: a Drupal user name, defaulting to the settings-defined anonymous.
-   *   - roles: an array of role names, possibly empty.
+   *   - Key uid: a Drupal user id, 0 if not logged on Drupal
+   *   - Key name: a Drupal user name, defaulting to the settings-defined anonymous.
+   *   - Key roles: an array of role names, possibly empty.
    */
   whoamiMethod(cookieName, cookieValue) {
     const url = this.settings.server.site + '/meteor/whoami';
@@ -631,4 +635,4 @@ class DrupalServer extends DrupalBase {
 
 export {
   DrupalServer,
-}
+};

--- a/sv/makeServer.js
+++ b/sv/makeServer.js
@@ -68,7 +68,7 @@ const makeServer = (json, accounts, http, match, meteor, serviceConfiguration, w
     server.registerWebRoute();
     logger.debug('HTTP routes bound.');
 
-    logger.debug('Accounts-drupal configured');
+    logger.debug(`${DrupalBase.SERVICE_NAME} login service configured`);
   }
   catch (e) {
     // Do not return an apparently usable instance if an exception occurred.

--- a/sv/makeServer.js
+++ b/sv/makeServer.js
@@ -3,24 +3,33 @@
  *   Contains accounts-drupal server-side non-object code.
  */
 
-import { DrupalBase } from "../shared/DrupalBase";
-import { DrupalConfiguration } from "./DrupalConfiguration";
-import { DrupalServer } from "./DrupalServer";
+import { DrupalBase } from '../shared/DrupalBase';
+import { DrupalConfiguration } from './DrupalConfiguration';
+import { DrupalServer } from './DrupalServer';
 
 /**
  * Build and completely initialize a "Drupal" server instance.
  *
- * @param json
- * @param accounts
- * @param http
- * @param match
- * @param meteor
- * @param serviceConfiguration
- * @param logger
- * @param settings
- * @param webapp
+ * @param {Object} json
+ *   A service compatible with Meteor json.
+ * @param {Object} accounts
+ *   A service compatible with Meteor Accounts-base package.
+ * @param {Object} http
+ *   A service compatible with Meteor http package.
+ * @param {Object} match
+ *   A service compatible with Meteor check package.
+ * @param {Object} meteor
+ *   A service compatible with the Meteor global.
+ * @param {Object} serviceConfiguration
+ *   A service compatible with the Meteor ServiceConfiguration type.
+ * @param {Object} webapp
+ *   A service compatible with Meteor WebApp.
+ * @param {Object} logger
+ *   A service compatible with Meteor Log.
+ * @param {Object} settings
+ *   The Meteor settings for the application.
  *
- * @return {DrupalServer|null}
+ * @returns {DrupalServer|Object}
  *   Will return null if the stream is unavailable or the instance creation or
  *   initialization fails.
  */
@@ -81,4 +90,4 @@ const makeServer = (json, accounts, http, match, meteor, serviceConfiguration, w
 
 export {
   makeServer,
-}
+};

--- a/sv/serverMain.js
+++ b/sv/serverMain.js
@@ -10,15 +10,15 @@
  * - it stores a Drupal instance as the "drupal" global.
  */
 
-import { Accounts } from "meteor/accounts-base";
-import { HTTP } from "meteor/http";
-import { Match } from "meteor/check";
-import { Meteor } from "meteor/meteor";
-import { ServiceConfiguration } from "meteor/service-configuration";
-import { WebApp } from "meteor/webapp";
+import { Accounts } from 'meteor/accounts-base';
+import { HTTP } from 'meteor/http';
+import { Match } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import { ServiceConfiguration } from 'meteor/service-configuration';
+import { WebApp } from 'meteor/webapp';
 
-import { Drupal } from "../shared/Drupal";
-import { makeServer } from "./makeServer";
+import { Drupal } from '../shared/Drupal';
+import { makeServer } from './makeServer';
 
 /**
  * A Meteor.startup() argument function.
@@ -27,10 +27,10 @@ import { makeServer } from "./makeServer";
  *
  * @param {Log} logger
  *   A Log-compatible logger.
- * @param {object} settings
+ * @param {Object} settings
  *   Meteor settings containing configuration for accounts-drupal.
  *
- * @return {void}
+ * @returns {undefined}
  */
 const onStartup = (logger, settings) => {
   logger.debug('Server startup');

--- a/sv/serverTests.js
+++ b/sv/serverTests.js
@@ -5,7 +5,7 @@ const SERVICE_NAME = 'mock-service';
 /**
  * Setup helper for tests: create a mock settings document.
  *
- * @param {String} serviceName
+ * @param {string} serviceName
  *   The name of the login service.
  *
  * @returns {{public: {}}}


### PR DESCRIPTION
This happens during cookieCheck.

Also, make logging more usable by reducing the level of some information and adding more context in other messages.